### PR TITLE
resource_hydra_jobset: check required type-specific fields are set

### DIFF
--- a/hydra/resource_hydra_jobset.go
+++ b/hydra/resource_hydra_jobset.go
@@ -272,6 +272,14 @@ func createJobsetPutBody(project string, jobset string, d *schema.ResourceData) 
 		}}
 	}
 
+	if jobsetType == 1 && flake_uri == "" {
+		return nil, []diag.Diagnostic{{
+			Severity: diag.Error,
+			Summary:  errsummary,
+			Detail:   "Jobset type \"flake\" requires a non-empty flake_uri.",
+		}}
+	}
+
 	if flake_uri != "" {
 		body.Flake = &flake_uri
 	}
@@ -282,6 +290,14 @@ func createJobsetPutBody(project string, jobset string, d *schema.ResourceData) 
 			Severity: diag.Error,
 			Summary:  errsummary,
 			Detail:   "You cannot specify a nix_expression when using type \"flake\".",
+		}}
+	}
+
+	if jobsetType == 0 && len(nix_expression.List()) < 1 {
+		return nil, []diag.Diagnostic{{
+			Severity: diag.Error,
+			Summary:  errsummary,
+			Detail:   "Jobset type \"legacy\" requires a non-empty nix_expression.",
 		}}
 	}
 
@@ -301,6 +317,14 @@ func createJobsetPutBody(project string, jobset string, d *schema.ResourceData) 
 			Severity: diag.Error,
 			Summary:  errsummary,
 			Detail:   "You cannot specify one or more inputs when using type \"flake\".",
+		}}
+	}
+
+	if jobsetType == 0 && len(input.List()) < 1 {
+		return nil, []diag.Diagnostic{{
+			Severity: diag.Error,
+			Summary:  errsummary,
+			Detail:   "Jobset type \"legacy\" requires non-empty input(s).",
 		}}
 	}
 


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/terraform-provider-hydra/issues/15.

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [x] Built with `make build`
- [x] Formatted with `make fmt`
- [x] Verifed the example configuration still parses with `terraform init &&
terraform validate` (you may need to `make install` from the root of the
project)
- [x] Ran acceptance tests with `HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice
HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local /
temporary instance of Hydra)
