### PR TITLE
resource_hydra_jobset: set flake_uri based on GET response

### DIFF
--- a/hydra/resource_hydra_jobset.go
+++ b/hydra/resource_hydra_jobset.go
@@ -449,6 +449,10 @@ func resourceHydraJobsetRead(ctx context.Context, d *schema.ResourceData, m inte
 		d.Set("email_override", *jobsetResponse.Emailoverride)
 	}
 
+	if jobsetResponse.Flake != nil && *jobsetResponse.Flake != "" {
+		d.Set("flake_uri", *jobsetResponse.Flake)
+	}
+
 	if (jobsetResponse.Nixexprinput != nil && *jobsetResponse.Nixexprinput != "") &&
 		(jobsetResponse.Nixexprpath != nil && *jobsetResponse.Nixexprpath != "") {
 		nix_expression := schema.NewSet(schema.HashResource(nixExprSchema()), []interface{}{


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/terraform-provider-hydra/issues/16.

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [x] Built with `make build`
- [x] Formatted with `make fmt`
- [x] Verifed the example configuration still parses with `terraform init &&
terraform validate` (you may need to `make install` from the root of the
project)
- [x] Ran acceptance tests with `HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice
HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local /
temporary instance of Hydra)
