### PR TITLE
docs: init

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,4 @@ building / formatting / testing / etc. --->
 - [ ] Formatted with `make fmt`
 - [ ] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
 - [ ] Ran acceptance tests with `HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
+- [ ] Added or updated relevant documentation (leave unchecked if not applicable)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,75 @@
+# Hydra Provider
+
+This provider allows one to manage the projects and jobsets of a particular
+[Hydra] instance.
+
+## Example Usage
+
+```terraform
+terraform {
+  required_providers {
+    hydra = {
+      version = "~> 0.1"
+      source  = "DeterminateSystems/hydra"
+    }
+  }
+}
+
+provider "hydra" {
+  host = "https://hydra.example.com"
+}
+```
+
+## Authentication
+
+The Hydra provider supports two means of providing authentication credentials:
+
+- Static credentials
+- Environment variables
+
+-> The user specified by either a static `username` or `HYDRA_USERNAME`
+environment variable should have the permissions necessary for project and
+jobset creation, modification, and deletion.
+
+### Environment Variables
+
+You can provide your credentials via the `HYDRA_USERNAME` and `HYDRA_PASSWORD`
+environment variables.
+
+```terraform
+provider "hydra" {
+  host = "https://hydra.example.com"
+}
+```
+
+### Static Credentials
+
+!> **Warning:** Hard-coded credentials are not recommended in any Terraform
+configuration and risks secret leakage should this file ever be committed to a
+public version control system.
+
+Static credentials can be provided by adding a `username` and `password` to the
+Hydra provider block:
+
+```terraform
+provider "hydra" {
+  host     = "https://hydra.example.com"
+  username = "alice"
+  password = "foobar"
+}
+```
+
+## Argument Reference
+
+* `host` - (Optional) This is the address of the Hydra instance. It must be
+provided, but it can also be sourced from the `HYDRA_HOST` environment variable.
+
+* `username` - (Optional) This is the user that Terraform will be logging in as.
+It must be provided, but it can also be sourced from the `HYDRA_USERNAME`
+environment variable.
+
+* `password` - (Optional) This is the password for the Hydra user specified in
+`username`. It must be provided, but it can also be sourced from the
+`HYDRA_PASSWORD` environment variable.
+
+[Hydra]: https://github.com/NixOS/hydra/

--- a/docs/resources/jobset.md
+++ b/docs/resources/jobset.md
@@ -1,0 +1,116 @@
+# Jobset Resource
+
+The Jobset resource defines a [Hydra jobset] to be managed by Terraform.
+
+## Example Usage
+
+### Type `legacy`
+
+```terraform
+resource "hydra_jobset" "trunk" {
+  project     = hydra_project.nixpkgs.name
+  state       = "enabled"
+  visible     = true
+  name        = "trunk"
+  type        = "legacy"
+  description = "master branch"
+
+  nix_expression {
+    file  = "pkgs/top-level/release.nix"
+    input = "nixpkgs"
+  }
+
+  check_interval    = 0
+  scheduling_shares = 3000
+
+  email_notifications = true
+  email_override      = "example@example.com"
+  keep_evaluations    = 3
+
+  input {
+    name              = "nixpkgs"
+    type              = "git"
+    value             = "https://github.com/NixOS/nixpkgs.git"
+    notify_committers = false
+  }
+
+  input {
+    name              = "officialRelease"
+    type              = "boolean"
+    value             = "false"
+    notify_committers = false
+  }
+}
+```
+
+### Type `flake`
+
+```terraform
+resource "hydra_jobset" "trunk-flake" {
+  project     = hydra_project.nixpkgs.name
+  state       = "enabled"
+  visible     = true
+  name        = "trunk-flake"
+  type        = "flake"
+  description = "master branch"
+
+  flake_uri = "github:NixOS/nixpkgs/master"
+
+  check_interval    = 0
+  scheduling_shares = 3000
+
+  email_notifications = true
+  email_override      = "example@example.com"
+  keep_evaluations    = 3
+}
+```
+
+## Argument Reference
+
+* `project` - (Required) The name of the parent project.
+
+* `state` - (Required) The state of the jobset. One of `disabled`, `enabled`,
+`one-shot`, or `one-at-a-time`.
+
+* `visible` - (Optional) Whether or not the jobset is visible.
+
+* `name` - (Required) The name of the jobset.
+
+* `type` - (Required) The type of the jobset. Either `legacy` or `flake`.
+
+* `description` - (Optional) The description of the jobset.
+
+* `flake_uri` - (Required when the `type` is `flake`, otherwise prohibited.) The
+jobset's flake URI.
+
+* `input` - (Required when the `type` is `legacy`, otherwise prohibited.)
+Input(s) to be provided to the jobset.
+
+  * `name` - (Required) The name of the input.
+
+  * `type` - (Required) The type of the input.
+
+  * `value` - (Required) The value of the jobset.
+
+  * `notify_committers` - (Optional) Whether or not to notify committers.
+
+* `nix_expression` - (Required when the `type` is `legacy`, otherwise
+prohibited.) The jobset's entrypoint Nix expression.
+
+  * `file` - (Required) The file containing the Nix expression.
+
+  * `input` - (Required) The input where the `file` is located.
+
+* `check_interval` - (Required) How frequently to check the jobset in seconds (0
+disables polling).
+
+* `scheduling_shares` - (Required) How many shares allocated to the jobset.
+
+* `email_notifications` - (Optional) Whether or not to send email notifications.
+
+* `email_override` - (Optional) An email, or a comma-separated list of emails,
+to send email notifications to.
+
+* `keep_evaluations` - (Required) How many of the jobset's evaluations to keep.
+
+[Hydra jobset]: https://github.com/NixOS/hydra/blob/e9a06113c955e457fa59717c4964c302e852ee9b/doc/manual/src/projects.md#job-sets

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -1,0 +1,35 @@
+# Project Resource
+
+The Project resource defines a [Hydra project] to be managed by Terraform.
+
+## Example Usage
+
+```terraform
+resource "hydra_project" "nixpkgs" {
+  name         = "nixpkgs"
+  display_name = "Nixpkgs"
+  description  = "Nix Packages collection"
+  homepage     = "http://nixos.org/nixpkgs"
+  owner        = "alice"
+  enabled      = true
+  visible      = true
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the project.
+
+* `display_name` - (Required) The display name of the project.
+
+* `description` - (Optional) A description of the project.
+
+* `homepage` - (Optional) The homepage of the project.
+
+* `owner` - (Required) The owner of the project (a Hydra user).
+
+* `enabled` - (Optional) Whether or not the project is enabled.
+
+* `visible` - (Optional) Whether or not the project is visible.
+
+[Hydra project]: https://github.com/NixOS/hydra/blob/e9a06113c955e457fa59717c4964c302e852ee9b/doc/manual/src/projects.md#creating-and-managing-projects

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     hydra = {
-      version = "0.1"
+      version = "~> 0.1"
       source  = "DeterminateSystems/hydra"
     }
   }


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/terraform-provider-hydra/issues/22.

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [x] Built with `make build`
- [x] Formatted with `make fmt`
- [x] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [x] Ran acceptance tests with `HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
