### PR TITLE
Split out examples

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -11,7 +11,7 @@ resource "hydra_project" "nixpkgs" {
   description  = "Nix Packages collection"
   homepage     = "http://nixos.org/nixpkgs"
   owner        = "alice"
-  enabled      = true
+  enabled      = false
   visible      = true
 
   declarative {

--- a/examples/declarative/main.tf
+++ b/examples/declarative/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    hydra = {
+      version = "~> 0.1"
+      source  = "DeterminateSystems/hydra"
+    }
+  }
+}
+
+provider "hydra" {
+  host     = "http://0:63333"
+  username = "alice"
+  password = "foobar"
+}
+
+resource "hydra_project" "nixpkgs-declarative" {
+  name         = "nixpkgs-declarative"
+  display_name = "Nixpkgs"
+  description  = "Nix Packages collection"
+  homepage     = "https://nixos.org/nixpkgs"
+  owner        = "alice"
+  enabled      = false
+  visible      = true
+
+  declarative {
+    file  = "static-declarative-project/declarative.json"
+    type  = "git"
+    value = "https://github.com/DeterminateSystems/hydra-examples.git main"
+  }
+}

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -17,16 +17,10 @@ resource "hydra_project" "nixpkgs" {
   name         = "nixpkgs"
   display_name = "Nixpkgs"
   description  = "Nix Packages collection"
-  homepage     = "http://nixos.org/nixpkgs"
+  homepage     = "https://nixos.org/nixpkgs"
   owner        = "alice"
   enabled      = true
   visible      = true
-
-  declarative {
-    file  = "static-declarative-project/declarative.json"
-    type  = "git"
-    value = "https://github.com/DeterminateSystems/hydra-examples.git main"
-  }
 }
 
 resource "hydra_jobset" "trunk" {


### PR DESCRIPTION
The specified declarative configuration will automatically evaluate / build if a
user tests this locally, so comment it out by default.

Also give it its own resource block to ensure we don't exemplify creating a
jobset on a declarative project (which, at the very least, the web version of
Hydra disallows).

##### Description

<!--- Please include a short description of what your PR does and / or the
motivation behind it --->

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [x] Built with `make build`
- [x] Formatted with `make fmt`
- [x] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [x] Ran acceptance tests with `HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
