### PR TITLE
resource_hydra_jobset: test changing jobset type legacy->flake->legacy

### DIFF
--- a/hydra/resource_hydra_jobset_test.go
+++ b/hydra/resource_hydra_jobset_test.go
@@ -176,6 +176,44 @@ func TestAccHydraJobset_inputs(t *testing.T) {
 	})
 }
 
+func TestAccHydraJobset_legacyToFlakeAndBack(t *testing.T) {
+	// identifier must start with a letter
+	name := fmt.Sprintf("j%s", acctest.RandString(7))
+	resourceName := "hydra_jobset.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHydraJobsetDestroy,
+		Steps: []resource.TestStep{
+			// Test creation of basic jobset
+			{
+				Config: testAccHydraJobsetConfigBasic(name, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckJobsetExists(resourceName),
+					testAccCheckJobsetType(resourceName, 0),
+				),
+			},
+			// Test jobset changing from legacy to flake
+			{
+				Config: testAccHydraJobsetConfigLegacyToFlake(name, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckJobsetExists(resourceName),
+					testAccCheckJobsetType(resourceName, 1),
+				),
+			},
+			// Test jobset changing from flake back to legacy
+			{
+				Config: testAccHydraJobsetConfigBasic(name, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckJobsetExists(resourceName),
+					testAccCheckJobsetType(resourceName, 0),
+				),
+			},
+		},
+	})
+}
+
 // testAccCheckExampleResourceDestroy verifies the Jobset has been destroyed
 func testAccCheckHydraJobsetDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*api.ClientWithResponses)
@@ -274,6 +312,53 @@ func testAccCheckJobsetInputsChanged(name string, inputName1 string, inputName2 
 			(jobset.Inputs.AdditionalProperties[inputName1].Name == nil || *jobset.Inputs.AdditionalProperties[inputName1].Name != inputName1) &&
 			(jobset.Inputs.AdditionalProperties[inputName2].Name == nil || *jobset.Inputs.AdditionalProperties[inputName2].Name != inputName2) {
 			return fmt.Errorf("Expected inputs to have changed")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckJobsetType(name string, jobsetType int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Resource not found for %s", name)
+		}
+
+		jobsetID := rs.Primary.Attributes["name"]
+		if jobsetID == "" {
+			return fmt.Errorf("No jobset is set for %s", name)
+		}
+		projectID := rs.Primary.Attributes["project"]
+		if projectID == "" {
+			return fmt.Errorf("No project is set for %s", name)
+		}
+
+		client := testAccProvider.Meta().(*api.ClientWithResponses)
+		ctx := context.Background()
+
+		get, err := client.GetJobsetProjectIdJobsetIdWithResponse(ctx, projectID, jobsetID)
+		if err != nil {
+			return err
+		}
+		defer get.HTTPResponse.Body.Close()
+
+		// Check to make sure the jobset was created
+		if get.HTTPResponse.StatusCode != http.StatusOK {
+			return fmt.Errorf("Expected jobset %s in project %s to be created", jobsetID, projectID)
+		}
+
+		jobsetResponse := get.JSON200
+		if jobsetType == 0 {
+			if (jobsetResponse.Flake != nil && *jobsetResponse.Flake != "") ||
+				(jobsetResponse.Type != nil && *jobsetResponse.Type == 1) {
+				return fmt.Errorf("Expected jobset %s in project %s to be type legacy", jobsetID, projectID)
+			}
+		} else if jobsetType == 1 {
+			if (jobsetResponse.Flake == nil || *jobsetResponse.Flake == "") ||
+				(jobsetResponse.Type != nil && *jobsetResponse.Type == 0) {
+				return fmt.Errorf("Expected jobset %s in project %s to be type flake", jobsetID, projectID)
+			}
 		}
 
 		return nil
@@ -585,4 +670,35 @@ resource "hydra_jobset" "test" {
     notify_committers = false
   }
 }`, project, os.Getenv("HYDRA_USERNAME"), jobset, inputName2, inputName1, inputName2)
+}
+
+func testAccHydraJobsetConfigLegacyToFlake(project string, jobset string) string {
+	return fmt.Sprintf(`
+resource "hydra_project" "test" {
+  name         = "%s"
+  display_name = "Nixpkgs"
+  description  = "Nix Packages set"
+  homepage     = "https://github.com/nixos/nixpkgs"
+  owner        = "%s"
+  enabled = true
+  visible = true
+}
+
+resource "hydra_jobset" "test" {
+  project     = hydra_project.test.name
+  state       = "enabled"
+  visible     = true
+  name        = "%s"
+  type        = "flake"
+  description = "master branch"
+
+  flake_uri = "github:NixOS/nixpkgs/master"
+
+  check_interval    = 0
+  scheduling_shares = 3000
+
+  email_notifications = true
+  email_override      = "example@example.com"
+  keep_evaluations    = 3
+}`, project, os.Getenv("HYDRA_USERNAME"), jobset)
 }


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/terraform-provider-hydra/issues/30.

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [x] Built with `make build`
- [x] Formatted with `make fmt`
- [x] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [x] Ran acceptance tests with `HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
