### PR TITLE
ci: remove unnecessary cache step, fix terraform check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,23 @@ jobs:
         uses: cachix/install-nix-action@v13
       - run: nix-shell --run 'make install'
       - name: Terraform fmt
-        run: nix-shell --run 'terraform -chdir=./examples fmt -check'
+        run: nix-shell --run 'terraform fmt -check -recursive ./examples'
       - name: Terraform init
-        run: nix-shell --run 'terraform -chdir=./examples init'
+        run: |
+          nix-shell --run '
+            for dir in $(find examples -type d); do
+              echo "initializing dir $dir"
+              terraform init $dir
+            done
+          '
       - name: Terraform validate
-        run: nix-shell --run 'terraform -chdir=./examples validate -no-color'
+        run: |
+          nix-shell --run '
+            for dir in $(find examples -type d); do
+              echo "validating dir $dir"
+              terraform validate -no-color $dir
+            done
+          '
       # TODO: needs hydra running
       # - name: Terraform plan
       #   run: nix-shell --run 'terraform -chdir=./examples plan -no-color'


### PR DESCRIPTION
##### Description

We broke this when we added multiple examples. Oops :)

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [ ] Built with `make build`
- [ ] Formatted with `make fmt`
- [ ] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [ ] Ran acceptance tests with `HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
