### PR TITLE
provider: strip username:password from Origin header

### DIFF
--- a/hydra/provider.go
+++ b/hydra/provider.go
@@ -109,8 +109,19 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		Username: &username,
 		Password: &password,
 	}
+
 	resp, err := c.PostLoginWithResponse(ctx, body, func(ctx context.Context, req *http.Request) error {
-		req.Header.Add("Origin", host)
+		origin, err := url.Parse(host)
+		if err != nil {
+			return err
+		}
+
+		// Set the User field to nil in order to strip out authentication information
+		// from the URI -- Hydra expects *only* the host (and port, if necessary) as
+		// the Origin.
+		origin.User = nil
+
+		req.Header.Add("Origin", origin.String())
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/terraform-provider-hydra/issues/40.

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [x] Built with `make build`
- [x] Formatted with `make fmt`
- [x] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [x] Ran acceptance tests with `HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
