### PR TITLE
tools/generator: skip jobsets named `.jobsets`

### DIFF
--- a/tools/generator.sh
+++ b/tools/generator.sh
@@ -244,6 +244,14 @@ generate() {
 
                     if [ -z "$declfile" ]; then
                         while read -r jobsetname; do
+                            if [ "$jobsetname" = ".jobsets" ]; then
+                                echo >&2
+                                echo "WARNING: $project is not declarative, but has a .jobsets jobset which has been ignored." >&2
+                                echo "         See https://github.com/NixOS/hydra/issues/960 for more information." >&2
+                                echo >&2
+                                continue
+                            fi
+
                             echo "Processing jobset '$projectname/$jobsetname'..." >&2
                             echo
                             jobset="$(curl --silent --header "Accept: application/json" "$serverRoot/jobset/$projectname/$jobsetname" | jq .)"


### PR DESCRIPTION
When going from a declarative project to a normal project, Hydra doesn't clean
up the `.jobsets` jobset, so we want to skip it.

##### Description

Fixes https://github.com/DeterminateSystems/terraform-provider-hydra/issues/43. Works around upstream Hydra bug(?) https://github.com/NixOS/hydra/issues/960.

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [x] Built with `make build`
- [x] Formatted with `make fmt`
- [x] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [x] Ran acceptance tests with `HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
