### PR TITLE
resource_hydra_project: simplify testAccCheckProjectChangeDeclFile

### DIFF
--- a/hydra/resource_hydra_project_test.go
+++ b/hydra/resource_hydra_project_test.go
@@ -98,7 +98,7 @@ func TestAccHydraProject_declarative(t *testing.T) {
 				ExpectError: regexp.MustCompile(`Plan: 0 to add, 1 to change, 0 to destroy`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProjectExists(resourceName),
-					testAccCheckProjectChangeDeclFile(resourceName, name),
+					testAccCheckProjectChangeDeclFile(resourceName),
 				),
 			},
 		},
@@ -163,16 +163,16 @@ func testAccCheckProjectExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckProjectChangeDeclFile(resourceName string, projectName string) resource.TestCheckFunc {
+func testAccCheckProjectChangeDeclFile(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resourceName]
+		rs, ok := s.RootModule().Resources[name]
 		if !ok {
-			return fmt.Errorf("Resource not found for %s", resourceName)
+			return fmt.Errorf("Resource not found for %s", name)
 		}
 
 		projectID := rs.Primary.ID
 		if projectID == "" {
-			return fmt.Errorf("No ID is set for %s", resourceName)
+			return fmt.Errorf("No ID is set for %s", name)
 		}
 
 		client := testAccProvider.Meta().(*api.ClientWithResponses)
@@ -193,7 +193,7 @@ func testAccCheckProjectChangeDeclFile(resourceName string, projectName string) 
 		// declarative config using the web UI
 		rs.Primary.Attributes["declarative.0.file"] = "bogus"
 		d := resourceHydraProject().Data(rs.Primary)
-		body := createProjectPutBody(projectName, d)
+		body := createProjectPutBody(projectID, d)
 		put, err := client.PutProjectIdWithResponse(ctx, projectID, *body)
 		if err != nil {
 			return err


### PR DESCRIPTION
##### Description

Extra arg isn't necessary since we're not changing the project name and so don't need the "old" one.

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [x] Built with `make build`
- [x] Formatted with `make fmt`
- [x] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [x] Ran acceptance tests with `HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
