### PR TITLE
Document Basic Authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,15 @@ change (or write your own example!)
 1. Commit and open a pull request (be sure to follow the checklist in the
 template)
 
+## FAQ
+
+#### Q. Does this provider support Basic Authentication?
+
+A. Yes! Just set the `HYDRA_HOST` environment variable to e.g.
+`https://user:password@hydra.example.com`. You can also set the `host` in your
+configuration to this, but hard-coded credentials are insecure and not
+recommended.
+
 ## License
 
 [MPL-2.0](LICENSE)

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,8 @@ provider "hydra" {
 
 * `host` - (Optional) This is the address of the Hydra instance. It must be
 provided, but it can also be sourced from the `HYDRA_HOST` environment variable.
+Additionally, it supports Basic Authentication (e.g.
+`https://user:password@hydra.example.com`).
 
 * `username` - (Optional) This is the user that Terraform will be logging in as.
 It must be provided, but it can also be sourced from the `HYDRA_USERNAME`


### PR DESCRIPTION
##### Description

Part of https://github.com/DeterminateSystems/terraform-provider-hydra/issues/40.

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [x] Built with `make build`
- [x] Formatted with `make fmt`
- [x] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [x] Ran acceptance tests with `HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
