### PR TITLE
Use 0.0.0.0 for local connection examples

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,5 @@ building / formatting / testing / etc. --->
 - [ ] Built with `make build`
 - [ ] Formatted with `make fmt`
 - [ ] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
-- [ ] Ran acceptance tests with `HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
+- [ ] Ran acceptance tests with `HYDRA_HOST=http://0.0.0.0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
 - [ ] Added or updated relevant documentation (leave unchecked if not applicable)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ unexpected happening.
 
 ```shell
 $ nix-shell
-nix-shell$ HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc
+nix-shell$ HYDRA_HOST=http://0.0.0.0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc
 ```
 
 ## Contributing

--- a/examples/declarative/main.tf
+++ b/examples/declarative/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "hydra" {
-  host     = "http://0:63333"
+  host     = "http://0.0.0.0:63333"
   username = "alice"
   password = "foobar"
 }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "hydra" {
-  host     = "http://0:63333"
+  host     = "http://0.0.0.0:63333"
   username = "alice"
   password = "foobar"
 }


### PR DESCRIPTION
For some reason, `http://0:63333` stopped working, but `0.0.0.0` and `127.0.0.1`
both work.

##### Description

<!--- Please include a short description of what your PR does and / or the
motivation behind it --->

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [ ] Built with `make build`
- [ ] Formatted with `make fmt`
- [ ] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [ ] Ran acceptance tests with `HYDRA_HOST=http://0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
