### PR TITLE
resource_hydra_project: don't read declarative even if type is non-empty

### DIFF
--- a/hydra/resource_hydra_project.go
+++ b/hydra/resource_hydra_project.go
@@ -228,7 +228,6 @@ func resourceHydraProjectRead(ctx context.Context, d *schema.ResourceData, m int
 		projectResponse.Declarative.Type != nil &&
 		projectResponse.Declarative.Value != nil &&
 		!(*projectResponse.Declarative.File == "" &&
-			*projectResponse.Declarative.Type == "" &&
 			*projectResponse.Declarative.Value == "") {
 		declarative := schema.NewSet(schema.HashResource(declInputSchema()), []interface{}{
 			map[string]interface{}{


### PR DESCRIPTION
If both `file` and `value` are empty, we want to ignore it, no matter the
`type`.

##### Description

Fixes a generated resource like:

```terraform
resource "hydra_project" "ofborg" {
  name         = "ofborg"
  display_name = "ofborg"
  homepage     = "https://github.com/grahamc/ofborg"
  description  = "grahamcofborg automation"
  owner        = "graham@grahamc.com"
  enabled      = true
  visible      = true
}
```

having a change to the plan, like so:

```
  # hydra_project.ofborg will be updated in-place
  ~ resource "hydra_project" "ofborg" {
        id           = "ofborg"
        name         = "ofborg"
        # (6 unchanged attributes hidden)

      - declarative {
          - type = "boolean" -> null
        }
    }
```

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [x] Built with `make build`
- [x] Formatted with `make fmt`
- [x] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [x] Ran acceptance tests with `HYDRA_HOST=http://0.0.0.0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
