### PR TITLE
README: bump required Hydra commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ To use this provider, you will need the following:
 
 * [Terraform] 0.13+
 * A Hydra instance running [commit
-`6e53767`](https://github.com/NixOS/hydra/commit/6e537671dfa21f89041cbe16f0b461fe44327038)
+`5b6b826`](https://github.com/NixOS/hydra/commit/5b6b8261fc0571c4ee678cbe829ba07ed9372ef0)
 or later
+
+> **NOTE**: You *can* use this provider with [commit
+> `6e53767`](https://github.com/NixOS/hydra/commit/6e537671dfa21f89041cbe16f0b461fe44327038)
+> (at the absolute earliest), but it has a known issue where some internal
+> fields were not nullified, leading to state differences between Hydra and
+> Terraform, and is *not* recommended.
 
 ## Getting started
 


### PR DESCRIPTION
The provider relies on `decltype`, `declvalue`, and `declfile` all being empty
to detect a jobset that is not declarative. However, this is only true starting
with
https://github.com/NixOS/hydra/commit/67b6f0d7ed989c4225dc3d41df950bdded00f4b6,
which clears `decltype` and `declvalue` when `declfile` is set to an empty
string.

##### Description

<!--- Please include a short description of what your PR does and / or the
motivation behind it --->

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [ ] Built with `make build`
- [ ] Formatted with `make fmt`
- [ ] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [ ] Ran acceptance tests with `HYDRA_HOST=http://0.0.0.0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
