### PR TITLE
resource_hydra_project: set declarative to nil if not declarative

### DIFF
--- a/hydra/resource_hydra_jobset.go
+++ b/hydra/resource_hydra_jobset.go
@@ -485,10 +485,14 @@ func resourceHydraJobsetRead(ctx context.Context, d *schema.ResourceData, m inte
 
 	if jobsetResponse.Emailoverride != nil && *jobsetResponse.Emailoverride != "" {
 		d.Set("email_override", *jobsetResponse.Emailoverride)
+	} else {
+		d.Set("email_override", nil)
 	}
 
 	if jobsetResponse.Flake != nil && *jobsetResponse.Flake != "" {
 		d.Set("flake_uri", *jobsetResponse.Flake)
+	} else {
+		d.Set("flake_uri", nil)
 	}
 
 	if (jobsetResponse.Nixexprinput != nil && *jobsetResponse.Nixexprinput != "") &&
@@ -501,12 +505,16 @@ func resourceHydraJobsetRead(ctx context.Context, d *schema.ResourceData, m inte
 		})
 
 		d.Set("nix_expression", nixExpression)
+	} else {
+		d.Set("nix_expression", nil)
 	}
 
 	if jobsetResponse.Inputs != nil {
 		inputs := schema.NewSet(schema.HashResource(inputSchema()), flattenInputs(jobsetResponse.Inputs.AdditionalProperties))
 
 		d.Set("input", inputs)
+	} else {
+		d.Set("input", nil)
 	}
 
 	newID := fmt.Sprintf("%s/%s", *jobsetResponse.Project, *jobsetResponse.Name)

--- a/hydra/resource_hydra_project.go
+++ b/hydra/resource_hydra_project.go
@@ -239,6 +239,8 @@ func resourceHydraProjectRead(ctx context.Context, d *schema.ResourceData, m int
 		})
 
 		d.Set("declarative", declarative)
+	} else {
+		d.Set("declarative", nil)
 	}
 
 	d.SetId(*projectResponse.Name)


### PR DESCRIPTION
Otherwise, the internal representation of the project would be incorrect.

##### Description

<!--- Please include a short description of what your PR does and / or the
motivation behind it --->

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [x] Built with `make build`
- [x] Formatted with `make fmt`
- [x] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [x] Ran acceptance tests with `HYDRA_HOST=http://0.0.0.0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)

---

I don't think Hydra can actually send a response without e.g. `flake_uri`, so I couldn't reason about a way to test that.