### PR TITLE
resource_hydra_jobset: fix emailresponsible field

### DIFF
--- a/hydra/resource_hydra_jobset.go
+++ b/hydra/resource_hydra_jobset.go
@@ -350,11 +350,19 @@ func createJobsetPutBody(project string, jobset string, d *schema.ResourceData) 
 			name := v["name"].(string)
 			inputType := v["type"].(string)
 			value := v["value"].(string)
-			inputs[name] = api.JobsetInput{
+			emailResponsible := v["notify_committers"].(bool)
+
+			jobsetInput := api.JobsetInput{
 				Name:  &name,
 				Type:  &inputType,
 				Value: &value,
 			}
+
+			if emailResponsible {
+				jobsetInput.Emailresponsible = &emailResponsible
+			}
+
+			inputs[name] = jobsetInput
 		}
 
 		body.Inputs = &api.Jobset_Inputs{


### PR DESCRIPTION
Whoops. We only tested with notify_committers set to false, so we never caught
this. If it was ever set to true, nothing would happen because we wouldn't
update the PUT body to actually set this field...

##### Description

<!--- Please include a short description of what your PR does and / or the
motivation behind it --->

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [x] Built with `make build`
- [x] Formatted with `make fmt`
- [x] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [x] Ran acceptance tests with `HYDRA_HOST=http://0.0.0.0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
