### PR TITLE
resource_hydra_jobset: use ExactlyOneOf instead of ConflictsWith

### DIFF
--- a/hydra/resource_hydra_jobset_test.go
+++ b/hydra/resource_hydra_jobset_test.go
@@ -52,7 +52,7 @@ func TestAccHydraJobset_basic(t *testing.T) {
 			// Test if jobset has all required fields set
 			{
 				Config:      testAccHydraJobsetConfigEmptyNixExpr(name, name),
-				ExpectError: regexp.MustCompile(`Jobset type "legacy" requires a non-empty nix_expression.`),
+				ExpectError: regexp.MustCompile(`one of .* must be specified`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobsetExists(resourceName),
 				),
@@ -105,18 +105,18 @@ func TestAccHydraJobset_flake(t *testing.T) {
 					testAccCheckJobsetExists(resourceName),
 				),
 			},
-			// Test invalid jobset identifier
+			// Test if jobset has all required fields set
 			{
-				Config:      testAccHydraJobsetConfigFlake(name, badname),
-				ExpectError: regexp.MustCompile("Invalid jobset identifier"),
+				Config:      testAccHydraJobsetConfigEmptyFlake(name, name),
+				ExpectError: regexp.MustCompile(`one of .* must be specified`),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobsetExists(resourceName),
 				),
 			},
-			// Test if jobset has all required fields set
+			// Test invalid jobset identifier
 			{
-				Config:      testAccHydraJobsetConfigEmptyFlake(name, name),
-				ExpectError: regexp.MustCompile(`Jobset type "flake" requires a non-empty flake_uri.`),
+				Config:      testAccHydraJobsetConfigFlake(name, badname),
+				ExpectError: regexp.MustCompile("Invalid jobset identifier"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckJobsetExists(resourceName),
 				),


### PR DESCRIPTION
Slightly simplifies some logic.

##### Description

<!--- Please include a short description of what your PR does and / or the
motivation behind it --->

##### Checklist

<!--- Use `nix-shell` for a shell with all the required dependencies for
building / formatting / testing / etc. --->

- [x] Built with `make build`
- [x] Formatted with `make fmt`
- [x] Verifed the example configuration still parses with `terraform init && terraform validate` (you may need to `make install` from the root of the project)
- [x] Ran acceptance tests with `HYDRA_HOST=http://0.0.0.0:63333 HYDRA_USERNAME=alice HYDRA_PASSWORD=foobar make testacc` (you will need to spin up a local / temporary instance of Hydra)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
