### PR TITLE
DS-970: Add Magic Nix Cache and other workflow changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
             ${{ runner.os }}-go-
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - name: Enable magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Build
         run: nix-shell --run 'go build ./...'
 
@@ -30,6 +32,8 @@ jobs:
           fetch-depth: 0
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - name: Enable magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Check formatting
         run: |
           nix-shell --run '
@@ -45,6 +49,8 @@ jobs:
           fetch-depth: 0
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - name: Enable magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Check golint
         run: nix-shell --run 'golint -set_exit_status hydra'
 
@@ -62,6 +68,8 @@ jobs:
             ${{ runner.os }}-go-
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - name: Enable magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Test Go
         run: nix-shell --run 'go test ./...'
 
@@ -79,6 +87,8 @@ jobs:
             ${{ runner.os }}-go-
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - name: Enable magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix-shell --run 'make install'
       - name: Terraform fmt
         run: nix-shell --run 'terraform fmt -check -recursive ./examples'
@@ -116,6 +126,8 @@ jobs:
             ${{ runner.os }}-go-
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - name: Enable magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Check vendor is up-to-date
         run: |
           nix-shell --run '
@@ -133,6 +145,8 @@ jobs:
           fetch-depth: 0
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+      - name: Enable magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Shellcheck ./tools/
         working-directory: ./tools
         run: nix-shell --run 'shellcheck $(find . -type f -executable)'


### PR DESCRIPTION
 An assortment of GitHub Workflow changes, potentially including:

- Enable DeterminateSystems/magic-nix-cache-action@main
- Reference all DeterminateSystems actions via @main
- Make update.yaml consistent across repos
- Remove unnecessary github-token: from nix-installer-action
- Update actions/checkout@v2 to actions/checkout@v3
